### PR TITLE
Add EACL 2027 conference to conferences list

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -238,6 +238,19 @@
   sub: NLP
   note: ARR submission
 
+- title: EACL
+  year: 2027
+  id: eacl27
+  link: https://2027.eacl.org/
+  deadline: '2026-08-03 23:59:59'
+  timezone: UTC-12
+  place: Athens, Greece
+  date: March 9-14, 2027
+  start: 2027-03-09
+  end: 2027-03-14
+  sub: NLP
+  note: ARR submission
+
 - title: ICLR
   year: 2026
   id: iclr26


### PR DESCRIPTION
## Summary
Added EACL 2027 conference information to the conferences database.

## Changes
- Added new conference entry for EACL 2027 with the following details:
  - **Location**: Athens, Greece
  - **Dates**: March 9-14, 2027
  - **Submission deadline**: August 3, 2026 (UTC-12)
  - **Submission type**: ARR submission
  - **Conference link**: https://2027.eacl.org/

## Details
The entry follows the existing conference data structure and is positioned chronologically within the NLP conferences list.

https://claude.ai/code/session_01Dnm8U1N9f6FFDdfHtRm9Yp