### PR TITLE
Add AAAI 2027 deadline

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -519,3 +519,33 @@
   hindex: 212
   sub: ['DM', 'KR', 'ML', 'RO', 'NLP', 'SP', 'CV', 'CG', 'HCI', 'AP']
   note: Mandatory abstract deadline on Aug 07, 2024, and supplementary material deadline on Aug 19, 2024. More info <a href='https://aaai.org/conference/aaai/aaai-25/'>here</a>.
+
+- title: AAAI
+  year: 2027
+  id: aaai27
+  full_name: AAAI Conference on Artificial Intelligence
+  link: https://aaai.org/conference/aaai/aaai-27/
+  deadline: '2026-07-28 23:59:59'
+  abstract_deadline: '2026-07-21 23:59:59'
+  timezone: UTC-12
+  place: Montréal, Canada
+  date: February 16-23, 2027
+  start: 2027-02-16
+  end: 2027-02-23
+  hindex: 212
+  sub: ['DM', 'KR', 'ML', 'RO', 'NLP', 'SP', 'CV', 'CG', 'HCI', 'AP']
+  note: Mandatory abstract deadline on July 21, 2026. More info <a href='https://aaai.org/conference/aaai/aaai-27/'>here</a>.
+
+- title: RecSys
+  year: 2026
+  id: recsys26
+  full_name: ACM Conference on Recommender Systems
+  link: https://recsys.acm.org/recsys26/
+  deadline: '2026-07-15 23:59:59'
+  timezone: UTC-12
+  place: Minneapolis, USA
+  date: September 28 - October 02, 2026
+  start: 2026-09-28
+  end: 2026-10-02
+  sub: ML
+  note: Deadline for Research and Practice Notes. Main paper deadline was April 21, 2026.


### PR DESCRIPTION
## Summary
- **AAAI 2027** — Montréal, Canada, February 16-23, 2027. Abstract deadline July 21, 2026; full paper deadline July 28, 2026 (UTC-12).

## Test plan
- [ ] Verify entry renders correctly on the site

Sources:
- [AAAI-27 official page](https://aaai.org/conference/aaai/aaai-27/)