### PR TITLE
Remove RecSys 2026 entry

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -535,17 +535,3 @@
   hindex: 212
   sub: ['DM', 'KR', 'ML', 'RO', 'NLP', 'SP', 'CV', 'CG', 'HCI', 'AP']
   note: Mandatory abstract deadline on July 21, 2026. More info <a href='https://aaai.org/conference/aaai/aaai-27/'>here</a>.
-
-- title: RecSys
-  year: 2026
-  id: recsys26
-  full_name: ACM Conference on Recommender Systems
-  link: https://recsys.acm.org/recsys26/
-  deadline: '2026-07-15 23:59:59'
-  timezone: UTC-12
-  place: Minneapolis, USA
-  date: September 28 - October 02, 2026
-  start: 2026-09-28
-  end: 2026-10-02
-  sub: ML
-  note: Deadline for Research and Practice Notes. Main paper deadline was April 21, 2026.


### PR DESCRIPTION
## Summary
- Remove the RecSys 2026 entry that was added in #4. The main RecSys paper deadlines (long, short, reproducibility, resource, industry) all closed by May 21, 2026. The previously-listed "Research and Practice Notes" deadline (July 15, 2026) is a secondary track and shouldn't represent the conference in the tracker.

## Test plan
- [ ] Verify RecSys 2026 no longer appears on the site
- [ ] Confirm AAAI 2027 entry (also from #4) is unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dnm8U1N9f6FFDdfHtRm9Yp)_